### PR TITLE
Switch to Codecov v3 and explicitly add token

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -42,7 +42,8 @@ jobs:
       - name: list files
         run: ls -l .
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: coverage.xml


### PR DESCRIPTION
Aiming to fix
https://github.com/sjdemartini/graphene-django-permissions/actions/runs/7026559111/job/19119554372